### PR TITLE
Allow learn.microsoft.com to localize content

### DIFF
--- a/docs/com-programming/basics.md
+++ b/docs/com-programming/basics.md
@@ -131,6 +131,6 @@ during the execution of your code.
 
 ::::
 
-[C library]: https://docs.microsoft.com/en-us/windows/win32/learnwin32/creating-an-object-in-com
+[C library]: https://learn.microsoft.com/windows/win32/learnwin32/creating-an-object-in-com
 [Finalizer]: https://api.dart.dev/stable/dart-core/Finalizer-class.html
-[Microsoft documentation]: https://docs.microsoft.com/en-us/windows/win32/learnwin32/asking-an-object-for-an-interface
+[Microsoft documentation]: https://learn.microsoft.com/windows/win32/learnwin32/asking-an-object-for-an-interface

--- a/docs/win32-programming/callbacks.md
+++ b/docs/win32-programming/callbacks.md
@@ -21,7 +21,7 @@ thread are incompatible with this model. See [issue
 :::
 
 As an example of creating a callback, let's look at the
-[`EnumFontFamiliesEx`](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-enumfontfamiliesexw)
+[`EnumFontFamiliesEx`](https://learn.microsoft.com/windows/win32/api/wingdi/nf-wingdi-enumfontfamiliesexw)
 function, which enumerates all uniquely-named fonts in the system that match a
 specified set of font characteristics. `EnumFontFamiliesEx` takes a `LOGFONT`
 struct which contains the

--- a/docs/win32-programming/functions.md
+++ b/docs/win32-programming/functions.md
@@ -8,7 +8,7 @@ Win32 functions are exposed through `package:win32` as global Dart functions, so
 you can call them just like any other Dart function. For consistency with the
 C-based functions that they wrap, they are named with title case rather than the
 Dart camel case convention. Here's a simple example of calling the
-[`Beep`](https://learn.microsoft.com/en-us/windows/win32/api/utilapiset/nf-utilapiset-beep)
+[`Beep`](https://learn.microsoft.com/windows/win32/api/utilapiset/nf-utilapiset-beep)
 API to play an A<sub>4</sub> note for ½ second:
 
 ```dart

--- a/docs/win32-programming/memory-patterns.md
+++ b/docs/win32-programming/memory-patterns.md
@@ -5,7 +5,7 @@ sidebar_position: 6
 # Patterns for memory management
 
 Consider the following (bad) example of a function that calls
-[`CoCreateGuid`](https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cocreateguid)
+[`CoCreateGuid`](https://learn.microsoft.com/windows/win32/api/combaseapi/nf-combaseapi-cocreateguid)
 to return a String. Can you see a potential bug in this code?
 
 ```dart

--- a/docs/win32-programming/memory.md
+++ b/docs/win32-programming/memory.md
@@ -96,7 +96,7 @@ responsible for freeing its memory.
 If you want to create a new string, Win32 provides a simple function `wsalloc`,
 which allocates the necessary storage. This is particularly useful when you wish
 to _receive_ a string from Windows. The following example calls the Win32
-[`SHGetFolderPath`](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetfolderpathw)
+[`SHGetFolderPath`](https://learn.microsoft.com/windows/win32/api/shlobj_core/nf-shlobj_core-shgetfolderpathw)
 API to retrieve the directory of the Desktop folder:
 
 ```dart

--- a/docs/win32-programming/structs.md
+++ b/docs/win32-programming/structs.md
@@ -9,7 +9,7 @@ This topic provides more information on how to create, pass and access struct
 objects from Dart code.
 
 For example, let's assume you want to call the Win32 API
-[`GetSystemPowerStatus`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getsystempowerstatus),
+[`GetSystemPowerStatus`](https://learn.microsoft.com/windows/win32/api/winbase/nf-winbase-getsystempowerstatus),
 which retrieves the current power status of the system (e.g. battery or AC
 powered).
 

--- a/docs/winrt-programming/basics.md
+++ b/docs/winrt-programming/basics.md
@@ -109,11 +109,11 @@ during the execution of your code.
 
 ::::
 
-[Calendar]: https://learn.microsoft.com/en-us/uwp/api/windows.globalization.calendar
+[Calendar]: https://learn.microsoft.com/uwp/api/windows.globalization.calendar
 [dartwinrt]: https://github.com/dart-windows/dartwinrt
 [Finalizer]: https://api.dart.dev/stable/dart-core/Finalizer-class.html
 [issue tracker]: https://github.com/dart-windows/dartwinrt/issues
-[IVector]: https://learn.microsoft.com/en-us/uwp/api/windows.foundation.collections.ivector-1
+[IVector]: https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1
 [packages]: https://github.com/dart-windows/dartwinrt#packages-
 [windows_globalization]: https://pub.dev/packages/windows_globalization
-[Windows.Globalization]: https://learn.microsoft.com/en-us/uwp/api/windows.globalization
+[Windows.Globalization]: https://learn.microsoft.com/uwp/api/windows.globalization

--- a/docs/winrt-programming/limitations.md
+++ b/docs/winrt-programming/limitations.md
@@ -58,10 +58,10 @@ for more information.
 
 :::
 
-[IAsyncActionWithProgress]: https://learn.microsoft.com/en-us/uwp/api/windows.foundation.iasyncactionwithprogress-1
-[IAsyncOperationWithProgress]: https://learn.microsoft.com/en-us/uwp/api/windows.foundation.iasyncoperationwithprogress-2
-[MSIX]: https://learn.microsoft.com/en-us/windows/msix/
-[NetworkInformation]: https://learn.microsoft.com/en-us/uwp/api/windows.networking.connectivity.networkinformation
-[NetworkStatusChanged]: https://learn.microsoft.com/en-us/uwp/api/windows.networking.connectivity.networkinformation.networkstatuschanged
-[package identity]: https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/package-identity-overview
-[Windows Runtime APIs not supported in desktop apps]: https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-supported-api
+[IAsyncActionWithProgress]: https://learn.microsoft.com/uwp/api/windows.foundation.iasyncactionwithprogress-1
+[IAsyncOperationWithProgress]: https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2
+[MSIX]: https://learn.microsoft.com/windows/msix/
+[NetworkInformation]: https://learn.microsoft.com/uwp/api/windows.networking.connectivity.networkinformation
+[NetworkStatusChanged]: https://learn.microsoft.com/uwp/api/windows.networking.connectivity.networkinformation.networkstatuschanged
+[package identity]: https://learn.microsoft.com/windows/apps/desktop/modernize/package-identity-overview
+[Windows Runtime APIs not supported in desktop apps]: https://learn.microsoft.com/windows/apps/desktop/modernize/desktop-to-uwp-supported-api


### PR DESCRIPTION
Removing the `en-us` language code from the URL's path allows the docs website redirect to whichever locale is most appropriate for the user.